### PR TITLE
fix: Meminator Python: Fix typo in comment

### DIFF
--- a/services/meminator-python/src/server.py
+++ b/services/meminator-python/src/server.py
@@ -28,7 +28,7 @@ def meminate():
     # request_span = trace.get_current_span()
 
     phrase = input.get("phrase", "words go here").upper()
-    # request_span.set_attribute("app.phrase", phrase) # INSINSTRUMENTATIONTR: add important bits
+    # request_span.set_attribute("app.phrase", phrase) # INSTRUMENTATION: add important bits
 
     imageUrl = input.get("imageUrl", "http://missing.booo/no-url-here.png")
     # request_span.set_attribute("app.imageUrl", imageUrl)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes NONE

## Short description of the changes

Corrects a typo comment in tutorial code for meminator-python

## How to verify that this has the expected result

Visually
