### PR TITLE
fix: Meminator NodeJs: Add machine ID to docker to avoid missing file in OTEL library

### DIFF
--- a/services/meminator-nodejs/Dockerfile
+++ b/services/meminator-nodejs/Dockerfile
@@ -25,7 +25,11 @@ COPY tsconfig.json .
 COPY ./tmp ./tmp
 COPY ./src ./src
 
-RUN npx tsc 
+RUN mkdir -p /var/lib/dbus
+RUN echo 'nodejs-docker' > /etc/machine-id
+RUN echo 'nodejs-docker' > /var/lib/dbus/machine-id
+
+RUN npx tsc
 
 
 # Expose the port that your app runs on


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes NA

## Short description of the changes

This change works around an issue where Docker may start without a machine id.
This ID is needed by the nodejs OTEL library

## How to verify that this has the expected result

Switch language to `nodejs`

./run

Query memeinator and look for ENOENT no such file or directory '/var/lib/dbus/machine-id' errors

Add patch

Errors should be resolved


## Example error span

https://ui.honeycomb.io/jay.riley.pratt-gettingstarted/environments/test/datasets/backend-for-frontend-nodejs/result/7aTAav187Bd/trace/mEJQQaEELp4?fields[]=s_name&fields[]=s_serviceName&source=query&span=b4f0da0d610848c4
